### PR TITLE
Fix failing data scrape: FantasyPros ADP now login-gated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ __pycache__
 **/packages/
 build/
 out/
+# Local Python virtualenv used for debugging the data pipeline
+data/.venv/

--- a/data/aggregate.py
+++ b/data/aggregate.py
@@ -2,6 +2,7 @@
 """
 
 import datetime
+import glob
 import logging
 import os
 import re
@@ -65,7 +66,7 @@ def aggregate():
 
     src = ["cbs", "espn", "nfl"]
 
-    df = pd.read_csv(ADP)
+    df = pd.read_csv(resolve_adp())
     df = df.set_index("key")
     for i, other in enumerate([CBS, ESPN, NFL]):
         other_src = "_" + src[i]
@@ -115,6 +116,30 @@ def aggregate():
     df.to_json(AGGREGATE_JSON, orient="table")
 
     logging.info("aggregated projections to: %s", AGGREGATE_JSON)
+
+
+def resolve_adp():
+    """Return the ADP file to use.
+
+    Prefer the current year's FantasyPros ADP. FantasyPros now gates the full ADP
+    report behind a free login, so the scraper often can't produce a current file;
+    in that case fall back to the most recent prior year we have on disk so the
+    pipeline keeps producing output (draft ordering is stale but early-season ADP is
+    low-signal anyway).
+    """
+
+    if os.path.exists(ADP):
+        return ADP
+
+    candidates = sorted(glob.glob(os.path.join(DIR, "raw", "adp", "FantasyPros-*.csv")))
+    if not candidates:
+        raise FileNotFoundError(f"no FantasyPros ADP file found (looked for {ADP})")
+
+    fallback = candidates[-1]
+    logging.warning(
+        "current-year ADP %s missing; falling back to %s", ADP, fallback
+    )
+    return fallback
 
 
 def camel(match):

--- a/data/scrape.py
+++ b/data/scrape.py
@@ -55,6 +55,10 @@ RAW_ADP = os.path.join(DIR, "raw", "adp")
 
 YEAR = datetime.datetime.now().year
 
+# Minimum number of ADP rows we expect from a FantasyPros page. If we get fewer, the
+# report is almost certainly gated behind a login and we should skip it.
+MIN_ADP_ROWS = 30
+
 TEAM_TO_ABRV_MAP = {
     "Cardinals": "ARI",
     "Falcons": "ATL",
@@ -198,18 +202,31 @@ COLUMN_MAP = {
 
 
 def scrape():
-    """Scrape from all the sources and save to ./data/raw"""
+    """Scrape from all the sources and save to ./data/raw
+
+    Each source is scraped independently: the sites change their markup often and
+    break one scraper at a time, so a single failing source should not throw away
+    the data we successfully collected from the others. We only raise if *every*
+    source failed (i.e. the run produced nothing).
+    """
+
+    sources = [scrape_espn, scrape_cbs, scrape_nfl, scrape_fantasy_pros]
+    failures = []
 
     try:
-        scrape_espn()
-        scrape_cbs()
-        scrape_nfl()
-        scrape_fantasy_pros()
+        for source in sources:
+            try:
+                source()
+            except Exception:
+                failures.append(source.__name__)
+                logging.exception("Failed to scrape %s -- continuing", source.__name__)
+    finally:
         DRIVER.quit()
-    except:
-        DRIVER.quit()
-        logging.exception("Failed to scrape")
-        raise
+
+    if len(failures) == len(sources):
+        raise RuntimeError(f"all scrapers failed: {failures}")
+    if failures:
+        logging.warning("finished scrape with failed sources: %s", failures)
 
 
 def scrape_espn():
@@ -619,33 +636,51 @@ def scrape_fantasy_pros():
         soup = BeautifulSoup(
             DRIVER.execute_script("return document.body.innerHTML"), "html.parser"
         )
-        table = soup.select(".player-table")[0]
-        table_body = table.find("tbody")
+        # The 2026 redesign renamed the table (was ".player-table") and changed the
+        # column layout to: Rank | Player (Bye) | POS | AVG.
+        tables = soup.select("table.mcu-table")
+        if not tables:
+            raise RuntimeError(
+                f"Fantasy Pros ADP table not found for {ppr_type} ({url}) -- "
+                "the page markup likely changed again"
+            )
+        table_body = tables[0].find("tbody")
 
         players = []
         for tr in table_body.find_all("tr"):
             tds = tr.find_all("td")
-
-            name_team_bye = tds[1]
-            if len(name_team_bye.find_all("small")) < 1:
+            if len(tds) < 4:
                 continue
 
-            name = name_team_bye.find_all("a")[0].get_text()
-            team = name_team_bye.find_all("small")[0].get_text()
+            player_cell = tds[1]
+            team_span = player_cell.select_one(".reports__player-team")
+            if team_span is None:
+                continue
+
+            name_el = player_cell.select_one(".reports__player-name--full")
+            links = player_cell.find_all("a")
+            name = (
+                name_el.get_text().strip()
+                if name_el is not None
+                else (links[0].get_text().strip() if links else "")
+            )
+
+            # team span looks like "DET (6)" -- team abbreviation then bye week.
+            team_bye = team_span.get_text().strip()
+            match = re.match(r"([A-Za-z]+)\s*\((\w+)\)", team_bye)
+            if match:
+                team, bye = match.group(1), match.group(2)
+            else:
+                team, bye = team_bye, ""
             if team == "WAS":
                 team = "WSH"
             if team == "JAC":
                 team = "JAX"
-            bye = name_team_bye.find_all("small")[-1].get_text()
-            bye = bye[1:-1]  # remove parenthesis
 
-            # get rid of the number suffix. Eg DST14 > DST
+            # get rid of the number suffix. Eg RB14 > RB
             pos = "".join([i for i in tds[2].get_text() if not i.isdigit()])
-            if pos == "DST":
-                name = name.split(" ")[-2]
-                team = TEAM_TO_ABRV_MAP[name]
 
-            adp = tds[-2].get_text()
+            adp = tds[-1].get_text()
 
             player_data = {
                 "name": name,
@@ -655,6 +690,15 @@ def scrape_fantasy_pros():
                 ppr_type: float(adp.replace(",", "")) if isinstance(adp, str) else adp,
             }
             players.append(player_data)
+
+        # FantasyPros now gates the full ADP report behind a free account -- logged
+        # out we only get the top handful of players. Bail loudly rather than write a
+        # near-empty file; aggregate.py falls back to the last good ADP.
+        if len(players) < MIN_ADP_ROWS:
+            raise RuntimeError(
+                f"Fantasy Pros ADP for {ppr_type} returned only {len(players)} rows "
+                f"(expected >= {MIN_ADP_ROWS}); the report is likely login-gated now"
+            )
 
         player_d = pd.DataFrame(players)
         player_d = add_key(player_d)


### PR DESCRIPTION
## What was failing

The nightly `data` GitHub Action has been failing every run. Root cause:

```
File "data/scrape.py", line 631, in scrape_fantasy_pros
    table = soup.select(".player-table")[0]
IndexError: list index out of range
```

FantasyPros redesigned their ADP pages:
1. The table class changed (`.player-table` → `.mcu-table`) and the columns are now `Rank | Player (Bye) | POS | AVG`.
2. **The full ADP report is now gated behind a free account** — logged out, only the top ~5 players render (confirmed via headless Selenium: page shows "Create a free account to unlock", "Consensus of 1 Sources", 5 rows regardless of scroll).

Because `scrape_fantasy_pros()` crashed on the missing selector, the whole scrape aborted — ESPN/CBS/NFL all scraped successfully but their data was thrown away.

## Fix

- **`scrape()`** now runs each source independently; one broken scraper no longer discards the others. It only fails the run if *every* source fails.
- **`scrape_fantasy_pros()`** parses the new `.mcu-table` layout, and bails loudly when fewer than `MIN_ADP_ROWS` (30) come back — i.e. the login gate — instead of writing a near-empty file.
- **`aggregate()`** falls back to the most recent prior-year FantasyPros ADP (currently 2025) when the current-year file is missing, so the pipeline keeps producing output. Early-season ADP is low-signal anyway.

## Verified locally

- New parser correctly extracts name/team/bye/pos/ADP from the live page, then trips the gate detection (5 < 30 rows).
- `aggregate()` runs end-to-end with the 2025 ADP fallback + staged projections → 608-row output with correct columns and draft ordering.

## Follow-up (needs your input)

To restore *fresh* ADP, the scraper needs to log into FantasyPros (free account). That means storing FantasyPros credentials as GitHub secrets and adding a login step. Happy to wire that up if you want it — otherwise the pipeline runs green on last-known ADP.